### PR TITLE
Use SCAN and add support for redis://:password@hostname:port?db=1 urls

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"log"
+	"net"
+	"net/url"
+	"strconv"
+)
+
+func parseRedisURI(s string) (server *Redis_Server, err error) {
+	// "redis://x:password@host.name:123?db=0"
+	// "redis://x:password@host.name:123"
+
+	// Defaults
+	host := "localhost"
+	password := ""
+	port := 6379
+	db := 0
+
+	u, err := url.Parse(s)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if u.Scheme != "redis" {
+		log.Fatal("Scheme must be redis")
+	}
+	q := u.Query()
+	dbS := q.Get("db")
+	if u.User != nil {
+		var ok bool
+		password, ok = u.User.Password()
+		if !ok {
+			password = ""
+		}
+	}
+
+	var p string
+	host, p, _ = net.SplitHostPort(u.Host)
+
+	if p != "" {
+		port, err = strconv.Atoi(p)
+		if err != nil {
+			log.Fatalf("Unable to convert port to integer for %s", err)
+		}
+	}
+
+	if dbS != "" {
+		db, err = strconv.Atoi(dbS)
+		if err != nil {
+			log.Fatalf("Unable to convert db to integer for %s", dbS)
+		}
+	}
+
+	return &Redis_Server{host: host, port: port, db: db, pass: password}, nil
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func assertFieldsEqual(t *testing.T, e *Redis_Server, a *Redis_Server) {
+	assert.Equal(t, e.host, a.host, "host should be set")
+	assert.Equal(t, e.port, a.port, "port should be set")
+	assert.Equal(t, e.db, a.db, "db should be set")
+	assert.Equal(t, e.pass, a.pass, "password should be set")
+}
+
+func TestParseURI(t *testing.T) {
+	s := "redis://x:password@host.com:123"
+	a, _ := parseURI(s)
+	e := &Redis_Server{
+		host: "host.com",
+		port: 123,
+		db:   0,
+		pass: "password",
+	}
+	assertFieldsEqual(t, e, a)
+
+	s2 := "host.com:123:0:password"
+	a2, _ := parseURI(s2)
+	assertFieldsEqual(t, e, a2)
+
+	s3 := "redis://localhost:6370"
+	a3, _ := parseURI(s3)
+	e3 := &Redis_Server{nil, nil, "localhost", 6370, 0, ""}
+	assertFieldsEqual(t, e3, a3)
+}
+
+func TestRedisURIParsing(t *testing.T) {
+	s := "redis://x:password@host.com:123"
+	a, _ := parseRedisURI(s)
+	e := &Redis_Server{
+		host: "host.com",
+		port: 123,
+		db:   0,
+		pass: "password",
+	}
+	assertFieldsEqual(t, e, a)
+}
+
+func TestRedisURIParsingWithDB(t *testing.T) {
+	s := "redis://x:password@host.com:123?db=0"
+	actual, _ := parseRedisURI(s)
+	expected := &Redis_Server{
+		host: "host.com",
+		port: 123,
+		db:   0,
+		pass: "password",
+	}
+	assertFieldsEqual(t, expected, actual)
+}
+
+func TestRHost_Split(t *testing.T) {
+	s := "localhost:6370:0:password"
+	actual, _ := rhost_split(s)
+	expected := &Redis_Server{nil, nil, "localhost", 6370, 0, "password"}
+
+	assertFieldsEqual(t, expected, actual)
+}


### PR DESCRIPTION
First off, thanks for writing this 👍 . It helps with migrating data when hosting provider locks down some access to system.

Here are my changes:
# Use REDIS SCAN instead of KEYS

SCAN preferred to KEYS for production use:
- http://redis.io/commands/scan
- http://redis.io/commands/keys

```
Warning: consider KEYS as a command that should only be used in
production environments with extreme care. It may ruin performance when
it is executed against large databases. This command is intended for
debugging and special operations, such as changing your keyspace layout.
Don't use KEYS in your regular application code. If you're looking for a
way to find keys in a subset of your keyspace, consider using SCAN or
sets.
```
# Optional URL Input Format

Adds support for redis:// type urls which are used in redis-cli, with
the optional extension of `?db=1` if db needs to be non-zero.

Adds specs to verify the behavior. Preferentially chooses that type of
link parsing if the url starts with redis:// prefix. Otherwise falls
through to existing behavior.

Uses INFO to get full key count. This is incorrect when selecting a subset of keys... but the alternate way doesn't give any prediction of status bar Total count because we're gradually iterating through keyspace rather than preloading, as is done with `KEYS`. Seems like an acceptable tradeoff for now, but I could remove it from the PR if desired.
# Note

I brought in a different redis client in addition to current one because it cleanly supports the REDIS `SCAN`. This is a messy hack but it's working well enough for now.

Cheers,
Zander
