### PR TITLE
Fully switch to go-redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ build: deps
 deps:
 	go get github.com/cheggaaa/pb
 	go get gopkg.in/redis.v4
-	go get menteslibres.net/gosexy/redis
 
 test:
 	go test

--- a/core.go
+++ b/core.go
@@ -31,49 +31,18 @@ func (pipe *Redis_Pipe) TransferThread(i int, ch chan Op) {
 			m.repch <- true
 			return
 		}
-		data, err := pipe.from.r.Dump(m.str)
-		if err != nil {
-			log.Printf("FAIL:DUMP:%s, %v\n", m.str, err)
+		dump := pipe.from.client.Dump(m.str)
+		if dump.Err() != nil {
+			log.Printf("FAIL:DUMP:%s, %v\n", m.str, dump.Err())
 		}
-		if len(data) == 0 {
+		if len(dump.Val()) == 0 {
 			continue
 		}
-		_, err = pipe.to.r.Restore(m.str, 0, data)
+		_, err := pipe.to.client.Restore(m.str, 0, dump.Val()).Result()
 		if err != nil {
 			log.Printf("FAIL:RESTORE:%s, %v\n", m.str, err)
 		}
 	}
-}
-
-func (serv *Redis_Server) Connect() error {
-	err := serv.r.ConnectNonBlock(serv.host, uint(serv.port))
-	if err != nil {
-		log.Fatal("Connect: Connecting to host/port: ", err)
-	}
-	if serv.pass != "" {
-		_, err = serv.r.Auth(serv.pass)
-		if err != nil {
-			log.Fatal("Connect: password incorrect: ", err)
-		}
-	}
-	_, err = serv.r.Select(int64(serv.db))
-	if err != nil {
-		log.Fatal("Connect: select db failure: ", err)
-	}
-	return nil
-}
-
-// Create a "pipe" between both redis servers
-func (pipe *Redis_Pipe) ConnectBoth() error {
-	err := pipe.from.Connect()
-	if err != nil {
-		log.Fatal("ConnectBoth: Connecting to \"from\" host/port: ", err)
-	}
-	err = pipe.to.Connect()
-	if err != nil {
-		log.Fatal("ConnectBoth: Connecting to \"to\" host/port: ", err)
-	}
-	return nil
 }
 
 func (pipe *Redis_Pipe) Init() ([]Redis_Pipe, chan Op) {
@@ -84,9 +53,6 @@ func (pipe *Redis_Pipe) Init() ([]Redis_Pipe, chan Op) {
 		pipes[i].keys = pipe.keys
 		pipes[i].from, _ = rhost_copy(pipe.from)
 		pipes[i].to, _ = rhost_copy(pipe.to)
-
-		/* connect to both redii */
-		pipes[i].ConnectBoth()
 	}
 
 	ch := make(chan Op, pipe.threads)

--- a/types.go
+++ b/types.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	goredis "gopkg.in/redis.v4"
-	"menteslibres.net/gosexy/redis"
 	"sync"
 )
 
@@ -14,7 +13,6 @@ type Redis_Pipe struct {
 }
 
 type Redis_Server struct {
-	r      *redis.Client
 	client *goredis.Client
 	host   string
 	port   int
@@ -23,8 +21,8 @@ type Redis_Server struct {
 }
 
 const (
-  OP_NOP = 0
-  OP_DIE = iota
+	OP_NOP = 0
+	OP_DIE = iota
 )
 
 type Op struct {

--- a/uri.go
+++ b/uri.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	goredis "gopkg.in/redis.v4"
 	"log"
-	"menteslibres.net/gosexy/redis"
 	"strconv"
 	"strings"
 )
@@ -58,7 +57,6 @@ func rhost_copy(r *Redis_Server) (*Redis_Server, error) {
 	}
 	c := goredis.NewClient(opts)
 	rs := &Redis_Server{
-		r:      redis.New(),
 		client: c,
 		host:   r.host,
 		port:   r.port,

--- a/utils_test.go
+++ b/utils_test.go
@@ -29,7 +29,7 @@ func TestParseURI(t *testing.T) {
 
 	s3 := "redis://localhost:6370"
 	a3, _ := parseURI(s3)
-	e3 := &Redis_Server{nil, nil, "localhost", 6370, 0, ""}
+	e3 := &Redis_Server{nil, "localhost", 6370, 0, ""}
 	assertFieldsEqual(t, e3, a3)
 }
 
@@ -60,7 +60,7 @@ func TestRedisURIParsingWithDB(t *testing.T) {
 func TestRHost_Split(t *testing.T) {
 	s := "localhost:6370:0:password"
 	actual, _ := rhost_split(s)
-	expected := &Redis_Server{nil, nil, "localhost", 6370, 0, "password"}
+	expected := &Redis_Server{nil, "localhost", 6370, 0, "password"}
 
 	assertFieldsEqual(t, expected, actual)
 }


### PR DESCRIPTION
Since go-redis has a convenient way to do REDIS SCAN, this commit
removes other dependency on prior redis lib.

I ran it locally, completed sync successfully. Then made sure specs look good.

Also removes a whole lot of code in the process, which is wonderful for long term maintenance 👍 
