### PR TITLE
update golang version in travis, support ipv6 and fix lint issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ services:
   - redis-server
 
 go:
-  - 1.5
-  - 1.6
+  - 1.13.x
+  - 1.14.x
+  - 1.15.x
   - tip
 
 matrix:

--- a/core.go
+++ b/core.go
@@ -60,8 +60,8 @@ func (pipe *Redis_Pipe) Init(replace bool) ([]Redis_Pipe, chan Op) {
 
 	for i := 0; i < pipe.threads; i++ {
 		pipes[i].keys = pipe.keys
-		pipes[i].from, _ = rhost_copy(pipe.from)
-		pipes[i].to, _ = rhost_copy(pipe.to)
+		pipes[i].from, _ = rHostCopy(pipe.from)
+		pipes[i].to, _ = rHostCopy(pipe.to)
 	}
 
 	ch := make(chan Op, pipe.threads)

--- a/types.go
+++ b/types.go
@@ -6,13 +6,13 @@ import (
 )
 
 type Redis_Pipe struct {
-	from    *Redis_Server
-	to      *Redis_Server
+	from    *RedisServer
+	to      *RedisServer
 	threads int
 	keys    string
 }
 
-type Redis_Server struct {
+type RedisServer struct {
 	client *goredis.Client
 	host   string
 	port   int

--- a/uri_test.go
+++ b/uri_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRHostSplit(t *testing.T) {
+	s, err := rHostSplit("[::]:6379:1:abc")
+	assert.NoError(t, err)
+	assert.Equal(t, "::", s.host)
+	assert.Equal(t, 6379, s.port)
+	assert.Equal(t, 1, s.db)
+	assert.Equal(t, "abc", s.pass)
+
+	s, err = rHostSplit("127.0.0.1:6379:1:abc")
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", s.host)
+	assert.Equal(t, 6379, s.port)
+	assert.Equal(t, 1, s.db)
+	assert.Equal(t, "abc", s.pass)
+}

--- a/usage.go
+++ b/usage.go
@@ -34,8 +34,7 @@ func usage() {
  * examples:
    redis-transfer localhost:6379 remotehost:6379:1:password "migrate:*" 50
    redis-transfer redis://localhost:6379 redis://user:password@remotehost?db=1 "migrate:*" 50
-   redis-transfer localhost:6379 remotehost:6379 "migrate:*" 50 --replace
-`)
+   redis-transfer localhost:6379 remotehost:6379 "migrate:*" 50 --replace`)
 
 	os.Exit(1)
 }

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 )
 
-func parseRedisURI(s string) (server *Redis_Server, err error) {
+func parseRedisURI(s string) (server *RedisServer, err error) {
 	// "redis://x:password@host.name:123?db=0"
 	// "redis://x:password@host.name:123"
 
@@ -51,7 +51,7 @@ func parseRedisURI(s string) (server *Redis_Server, err error) {
 		}
 	}
 
-	return &Redis_Server{host: host, port: port, db: db, pass: password}, nil
+	return &RedisServer{host: host, port: port, db: db, pass: password}, nil
 }
 
 // source: https://gobyexample.com/collection-functions

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func assertFieldsEqual(t *testing.T, e *Redis_Server, a *Redis_Server) {
+func assertFieldsEqual(t *testing.T, e *RedisServer, a *RedisServer) {
 	assert.Equal(t, e.host, a.host, "host should be set")
 	assert.Equal(t, e.port, a.port, "port should be set")
 	assert.Equal(t, e.db, a.db, "db should be set")
@@ -15,7 +15,7 @@ func assertFieldsEqual(t *testing.T, e *Redis_Server, a *Redis_Server) {
 func TestParseURI(t *testing.T) {
 	s := "redis://x:password@host.com:123"
 	a, _ := parseURI(s)
-	e := &Redis_Server{
+	e := &RedisServer{
 		host: "host.com",
 		port: 123,
 		db:   0,
@@ -29,14 +29,14 @@ func TestParseURI(t *testing.T) {
 
 	s3 := "redis://localhost:6370"
 	a3, _ := parseURI(s3)
-	e3 := &Redis_Server{nil, "localhost", 6370, 0, ""}
+	e3 := &RedisServer{nil, "localhost", 6370, 0, ""}
 	assertFieldsEqual(t, e3, a3)
 }
 
 func TestRedisURIParsing(t *testing.T) {
 	s := "redis://x:password@host.com:123"
 	a, _ := parseRedisURI(s)
-	e := &Redis_Server{
+	e := &RedisServer{
 		host: "host.com",
 		port: 123,
 		db:   0,
@@ -48,7 +48,7 @@ func TestRedisURIParsing(t *testing.T) {
 func TestRedisURIParsingWithDB(t *testing.T) {
 	s := "redis://x:password@host.com:123?db=0"
 	actual, _ := parseRedisURI(s)
-	expected := &Redis_Server{
+	expected := &RedisServer{
 		host: "host.com",
 		port: 123,
 		db:   0,
@@ -59,8 +59,8 @@ func TestRedisURIParsingWithDB(t *testing.T) {
 
 func TestRHost_Split(t *testing.T) {
 	s := "localhost:6370:0:password"
-	actual, _ := rhost_split(s)
-	expected := &Redis_Server{nil, "localhost", 6370, 0, "password"}
+	actual, _ := rHostSplit(s)
+	expected := &RedisServer{nil, "localhost", 6370, 0, "password"}
 
 	assertFieldsEqual(t, expected, actual)
 }


### PR DESCRIPTION
1. update golang version in travis to fix build failure in travis, like https://github.com/google/link022/issues/89
2. fix lint issue: remove the redundant newline  in println
3. support ipv6